### PR TITLE
Added GCObject.h include for missing FGCObject class def

### DIFF
--- a/Source/LuaMachine/Public/LuaMachine.h
+++ b/Source/LuaMachine/Public/LuaMachine.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "Modules/ModuleManager.h"
+#include "UObject/GCObject.h"
 #include "LuaState.h"
 
 DECLARE_MULTICAST_DELEGATE(FOnRegisteredLuaStatesChanged);


### PR DESCRIPTION
Adding the include for GCObject.h fixes these compilation errors in UE 4.25.1:
```
\Plugins\LuaMachine\Source\LuaMachine\Public\LuaMachine.h(13): error C2504: 'FGCObject': base class undefined
\Plugins\LuaMachine\Source\LuaMachine\Public\LuaMachine.h(35): error C3668: 'FLuaMachineModule::AddReferencedObjects': method with override specifier 'override' did not override any base class methods
```