### PR TITLE
lua state preinitialized hook

### DIFF
--- a/Source/LuaMachine/Private/LuaState.cpp
+++ b/Source/LuaMachine/Private/LuaState.cpp
@@ -190,6 +190,9 @@ ULuaState* ULuaState::GetLuaState(UWorld* InWorld)
 		SetField(-2, TCHAR_TO_ANSI(*Pair.Key));
 	}
 
+	// Allows subclassed states to handle package init if they need to
+	ReceiveLuaPackageInit();
+
 	// pop global table
 	Pop();
 
@@ -638,6 +641,10 @@ FLuaValue ULuaState::ToLuaValue(int Index, lua_State* State)
 	}
 
 	return LuaValue;
+}
+
+void ULuaState::ReceiveLuaPackageInit_Implementation()
+{
 }
 
 int32 ULuaState::GetTop()

--- a/Source/LuaMachine/Private/LuaState.cpp
+++ b/Source/LuaMachine/Private/LuaState.cpp
@@ -190,8 +190,9 @@ ULuaState* ULuaState::GetLuaState(UWorld* InWorld)
 		SetField(-2, TCHAR_TO_ANSI(*Pair.Key));
 	}
 
-	// Allows subclassed states to handle package init if they need to
-	ReceiveLuaPackageInit();
+	// This allows subclasses to do any last minute initialization on lua state before
+	// we load code
+	ReceiveLuaStatePreInitialized();
 
 	// pop global table
 	Pop();
@@ -641,10 +642,6 @@ FLuaValue ULuaState::ToLuaValue(int Index, lua_State* State)
 	}
 
 	return LuaValue;
-}
-
-void ULuaState::ReceiveLuaPackageInit_Implementation()
-{
 }
 
 int32 ULuaState::GetTop()
@@ -1218,6 +1215,11 @@ void ULuaState::ReceiveLuaLevelRemovedFromWorld_Implementation(ULevel * Level, U
 void ULuaState::ReceiveLuaLevelAddedToWorld_Implementation(ULevel * Level, UWorld * World)
 {
 
+}
+
+void ULuaState::ReceiveLuaStatePreInitialized_Implementation()
+{
+	
 }
 
 void ULuaState::ReceiveLuaStateInitialized_Implementation()

--- a/Source/LuaMachine/Private/LuaState.cpp
+++ b/Source/LuaMachine/Private/LuaState.cpp
@@ -190,12 +190,12 @@ ULuaState* ULuaState::GetLuaState(UWorld* InWorld)
 		SetField(-2, TCHAR_TO_ANSI(*Pair.Key));
 	}
 
+	// pop global table
+	Pop();
+
 	// This allows subclasses to do any last minute initialization on lua state before
 	// we load code
 	ReceiveLuaStatePreInitialized();
-
-	// pop global table
-	Pop();
 
 	int DebugMask = 0;
 	// install hooks

--- a/Source/LuaMachine/Public/LuaState.h
+++ b/Source/LuaMachine/Public/LuaState.h
@@ -247,7 +247,7 @@ public:
 	void ReceiveLuaLevelRemovedFromWorld(ULevel* Level, UWorld* World);
 
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua Package Initialization"))
-	void ReceiveLuaPackageInit();
+	void ReceiveLuaStatePreInitialized();
 	
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua State Initialized"))
 	void ReceiveLuaStateInitialized();

--- a/Source/LuaMachine/Public/LuaState.h
+++ b/Source/LuaMachine/Public/LuaState.h
@@ -246,6 +246,9 @@ public:
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua Level Removed From World"))
 	void ReceiveLuaLevelRemovedFromWorld(ULevel* Level, UWorld* World);
 
+	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua Package Initialization"))
+    void ReceiveLuaPackageInit();
+	
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua State Initialized"))
 	void ReceiveLuaStateInitialized();
 

--- a/Source/LuaMachine/Public/LuaState.h
+++ b/Source/LuaMachine/Public/LuaState.h
@@ -247,7 +247,7 @@ public:
 	void ReceiveLuaLevelRemovedFromWorld(ULevel* Level, UWorld* World);
 
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua Package Initialization"))
-    void ReceiveLuaPackageInit();
+	void ReceiveLuaPackageInit();
 	
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua State Initialized"))
 	void ReceiveLuaStateInitialized();

--- a/Source/LuaMachine/Public/LuaState.h
+++ b/Source/LuaMachine/Public/LuaState.h
@@ -246,7 +246,7 @@ public:
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua Level Removed From World"))
 	void ReceiveLuaLevelRemovedFromWorld(ULevel* Level, UWorld* World);
 
-	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua Package Initialization"))
+	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua State Pre Initialization"))
 	void ReceiveLuaStatePreInitialized();
 	
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua State Initialized"))


### PR DESCRIPTION
This allows subclassed LuaStates to peform last-minute initialization on luaState before the first code asset or file is run.

In my case, I'm adding additional fields to luaState outside of the LuaBlueprintPackagesTable, and need it to be available before my LuaState's code is run.