### PR TITLE
StructToLuaValue now also converts variables with enum class (uint8) …

### DIFF
--- a/Source/LuaMachine/Private/LuaState.cpp
+++ b/Source/LuaMachine/Private/LuaState.cpp
@@ -1877,6 +1877,15 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 	LUAVALUE_PROP_CAST(ClassProperty, UObject*);
 	LUAVALUE_PROP_CAST(ObjectProperty, UObject*);
 
+#if ENGINE_MINOR_VERSION >= 25
+	FEnumProperty* EnumProperty = CastField<FEnumProperty>(Property);
+
+	if (EnumProperty)
+	{
+		const uint8* EnumValue = EnumProperty->ContainerPtrToValuePtr<const uint8>(Buffer, Index);
+		return FLuaValue((int32)*EnumValue);
+	}
+#endif
 
 #if ENGINE_MINOR_VERSION >= 25
 	FObjectPropertyBase* ObjectPropertyBase = CastField<FObjectPropertyBase>(Property);


### PR DESCRIPTION
Only implemented for version 4.25 and upwards, as I don't have 4.24 or earlier installation to test with.