### PR TITLE
Engine Versioning Helpers + Versionining Fixes

### DIFF
--- a/Source/LuaMachine/Private/LuaBlueprintFunctionLibrary.cpp
+++ b/Source/LuaMachine/Private/LuaBlueprintFunctionLibrary.cpp
@@ -341,7 +341,7 @@ FString ULuaBlueprintFunctionLibrary::LuaValueToUTF8(const FLuaValue& Value)
 
 FLuaValue ULuaBlueprintFunctionLibrary::LuaValueFromUTF32(const FString& String)
 {
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FTCHARToUTF32 UTF32String(*String);
 	return FLuaValue((const char*)UTF32String.Get(), UTF32String.Length());
 #else
@@ -352,7 +352,7 @@ FLuaValue ULuaBlueprintFunctionLibrary::LuaValueFromUTF32(const FString& String)
 
 FString ULuaBlueprintFunctionLibrary::LuaValueToUTF32(const FLuaValue& Value)
 {
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FString ReturnValue;
 	TArray<uint8> Bytes = Value.ToBytes();
 	Bytes.Add(0);
@@ -534,7 +534,7 @@ UTexture2D* ULuaBlueprintFunctionLibrary::LuaValueToTransientTexture(int32 Width
 			return nullptr;
 		}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 		TArray<uint8> UncompressedBytes;
 #else
 		const TArray<uint8>* UncompressedBytes = nullptr;
@@ -547,7 +547,7 @@ UTexture2D* ULuaBlueprintFunctionLibrary::LuaValueToTransientTexture(int32 Width
 		PixelFormat = EPixelFormat::PF_B8G8R8A8;
 		Width = ImageWrapper->GetWidth();
 		Height = ImageWrapper->GetHeight();
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 		Bytes = UncompressedBytes;
 #else
 		Bytes = *UncompressedBytes;
@@ -606,7 +606,7 @@ void ULuaBlueprintFunctionLibrary::LuaHttpRequest(UObject* WorldContextObject, T
 	if (!L)
 		return;
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 26
+#if UE4_AT_LEAST(26)
 	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
 #else
 	TSharedRef<IHttpRequest> HttpRequest = FHttpModule::Get().CreateRequest();
@@ -675,7 +675,7 @@ void ULuaBlueprintFunctionLibrary::LuaRunURL(UObject* WorldContextObject, TSubcl
 			return;
 		}
 	}
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 26
+#if UE4_AT_LEAST(26)
 	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
 #else
 	TSharedRef<IHttpRequest> HttpRequest = FHttpModule::Get().CreateRequest();
@@ -949,7 +949,7 @@ FLuaValue ULuaBlueprintFunctionLibrary::GetLuaComponentByStateAsLuaValue(AActor*
 {
 	if (!Actor)
 		return FLuaValue();
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION < 24
+#if UE4_LESS_THAN(24)
 	TArray<UActorComponent*> Components = Actor->GetComponentsByClass(ULuaComponent::StaticClass());
 #else
 	TArray<UActorComponent*> Components;
@@ -975,7 +975,7 @@ FLuaValue ULuaBlueprintFunctionLibrary::GetLuaComponentByNameAsLuaValue(AActor* 
 	if (!Actor)
 		return FLuaValue();
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION < 24
+#if UE4_LESS_THAN(24)
 	TArray<UActorComponent*> Components = Actor->GetComponentsByClass(ULuaComponent::StaticClass());
 #else
 	TArray<UActorComponent*> Components;
@@ -1001,7 +1001,7 @@ FLuaValue ULuaBlueprintFunctionLibrary::GetLuaComponentByStateAndNameAsLuaValue(
 	if (!Actor)
 		return FLuaValue();
 
-#if ENGINE_MINOR_VERSION < 24
+#if UE4_LESS_THAN(24)
 	TArray<UActorComponent*> Components = Actor->GetComponentsByClass(ULuaComponent::StaticClass());
 #else
 	TArray<UActorComponent*> Components;
@@ -1820,7 +1820,7 @@ bool ULuaBlueprintFunctionLibrary::LuaLoadPakFile(const FString& Filename, FStri
 		bCustomPakPlatformFile = true;
 	}
 
-#if	ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION > 26
+#if UE5_AT_LEAST(0)
 	TRefCountPtr<FPakFile> PakFile = new FPakFile(PakPlatformFile, *Filename, false);
 #else
 	FPakFile PakFile(PakPlatformFile, *Filename, false);
@@ -1836,7 +1836,7 @@ bool ULuaBlueprintFunctionLibrary::LuaLoadPakFile(const FString& Filename, FStri
 		return false;
 	}
 
-#if	ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION > 26
+#if UE5_AT_LEAST(0)
 	FString PakFileMountPoint = PakFile->GetMountPoint();
 #else
 	FString PakFileMountPoint = PakFile.GetMountPoint();
@@ -1846,7 +1846,7 @@ bool ULuaBlueprintFunctionLibrary::LuaLoadPakFile(const FString& Filename, FStri
 
 	FPaths::MakeStandardFilename(PakFileMountPoint);
 
-#if	ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION > 26
+#if UE5_AT_LEAST(0)
 	PakFile->SetMountPoint(*PakFileMountPoint);
 #else
 	PakFile.SetMountPoint(*PakFileMountPoint);
@@ -1876,7 +1876,7 @@ bool ULuaBlueprintFunctionLibrary::LuaLoadPakFile(const FString& Filename, FStri
 	IAssetRegistry& AssetRegistry = FModuleManager::LoadModuleChecked<FAssetRegistryModule>(TEXT("AssetRegistry")).Get();
 
 #if WITH_EDITOR
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION > 23
+#if UE4_AT_LEAST(23)
 	int32 bPreviousGAllowUnversionedContentInEditor = GAllowUnversionedContentInEditor;
 #else
 	bool bPreviousGAllowUnversionedContentInEditor = GAllowUnversionedContentInEditor;

--- a/Source/LuaMachine/Private/LuaDelegate.cpp
+++ b/Source/LuaMachine/Private/LuaDelegate.cpp
@@ -23,7 +23,7 @@ void ULuaDelegate::ProcessEvent(UFunction* Function, void* Parms)
 	}
 
 	TArray<FLuaValue> LuaArgs;
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> It(LuaDelegateSignature); (It && (It->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm); ++It)
 	{
 		FProperty* Prop = *It;

--- a/Source/LuaMachine/Private/LuaState.cpp
+++ b/Source/LuaMachine/Private/LuaState.cpp
@@ -965,7 +965,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 	void* Parameters = FMemory_Alloca(LuaCallContext->Function->ParmsSize);
 	FMemory::Memzero(Parameters, LuaCallContext->Function->ParmsSize);
 
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 	{
 		FProperty* Prop = *It;
@@ -987,7 +987,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 	}
 
 	// arguments
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> FArgs(LuaCallContext->Function.Get()); FArgs && ((FArgs->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm); ++FArgs)
 	{
 		FProperty* Prop = *FArgs;
@@ -1000,7 +1000,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 #endif
 		if (!LuaProp)
 		{
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 			FArrayProperty* ArrayProp = CastField<FArrayProperty>(Prop);
 			if (ArrayProp)
 			{
@@ -1077,7 +1077,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 	int ReturnedValues = 0;
 
 	// get return value
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> FArgs(LuaCallContext->Function.Get()); FArgs; ++FArgs)
 	{
 		FProperty* Prop = *FArgs;
@@ -1096,7 +1096,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 		{
 			continue;
 		}
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 		FStructProperty* LuaProp = CastField<FStructProperty>(Prop);
 		if (!LuaProp)
 		{
@@ -1142,7 +1142,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 		}
 	}
 
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 #else
 	for (TFieldIterator<UProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
@@ -1205,7 +1205,7 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 	void* Parameters = FMemory_Alloca(LuaCallContext->Function->ParmsSize);
 	FMemory::Memzero(Parameters, LuaCallContext->Function->ParmsSize);
 
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 	{
 		FProperty* Prop = *It;
@@ -1227,7 +1227,7 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 	}
 
 	// arguments
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> FArgs(LuaCallContext->Function.Get()); FArgs && ((FArgs->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm); ++FArgs)
 	{
 		FProperty* Prop = *FArgs;
@@ -1273,7 +1273,7 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 	int ReturnedValues = 0;
 
 	// get return value
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> FArgs(LuaCallContext->Function.Get()); FArgs; ++FArgs)
 	{
 		FProperty* Prop = *FArgs;
@@ -1299,7 +1299,7 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 		LuaState->FromLuaValue(LuaValue, nullptr, L);
 	}
 
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 #else
 	for (TFieldIterator<UProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
@@ -1913,7 +1913,7 @@ ULuaState::~ULuaState()
 		lua_close(L);
 }
 
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 #define LUAVALUE_PROP_CAST(Type, Type2) F##Type* __##Type##__ = CastField<F##Type>(Property);\
 	if (__##Type##__)\
 	{\
@@ -1953,7 +1953,7 @@ ULuaState::~ULuaState()
 	}
 #endif
 
-#if	ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 FLuaValue ULuaState::FromUProperty(void* Buffer, FProperty * Property, bool& bSuccess, int32 Index)
 {
 	return FromFProperty(Buffer, Property, bSuccess, Index);
@@ -1964,7 +1964,7 @@ void ULuaState::ToUProperty(void* Buffer, FProperty * Property, FLuaValue Value,
 }
 #endif
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 FLuaValue ULuaState::FromFProperty(void* Buffer, FProperty * Property, bool& bSuccess, int32 Index)
 #else
 FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSuccess, int32 Index)
@@ -1988,7 +1988,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 	LUAVALUE_PROP_CAST(ClassProperty, UObject*);
 	LUAVALUE_PROP_CAST(ObjectProperty, UObject*);
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FEnumProperty* EnumProperty = CastField<FEnumProperty>(Property);
 
 	if (EnumProperty)
@@ -1998,7 +1998,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 	}
 #endif
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FObjectPropertyBase* ObjectPropertyBase = CastField<FObjectPropertyBase>(Property);
 #else
 	UObjectPropertyBase* ObjectPropertyBase = Cast<UObjectPropertyBase>(Property);
@@ -2008,7 +2008,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 		return FLuaValue(ObjectPropertyBase->GetObjectPropertyValue_InContainer(Buffer, Index));
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FWeakObjectProperty* WeakObjectProperty = CastField<FWeakObjectProperty>(Property);
 #else
 	UWeakObjectProperty* WeakObjectProperty = Cast<UWeakObjectProperty>(Property);
@@ -2019,7 +2019,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 		return FLuaValue(WeakPtr.Get());
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FMulticastDelegateProperty* MulticastProperty = CastField<FMulticastDelegateProperty>(Property))
 #else
 	if (UMulticastDelegateProperty* MulticastProperty = Cast<UMulticastDelegateProperty>(Property))
@@ -2030,7 +2030,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 		return CreateLuaTable();
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FDelegateProperty* DelegateProperty = CastField<FDelegateProperty>(Property))
 #else
 	if (UDelegateProperty* DelegateProperty = Cast<UDelegateProperty>(Property))
@@ -2040,7 +2040,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 		return FLuaValue::FunctionOfObject((UObject*)ScriptDelegate.GetUObject(), ScriptDelegate.GetFunctionName());
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FArrayProperty* ArrayProperty = CastField<FArrayProperty>(Property))
 #else
 	if (UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Property))
@@ -2057,7 +2057,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 		return NewLuaArray;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FMapProperty* MapProperty = CastField<FMapProperty>(Property))
 #else
 	if (UMapProperty* MapProperty = Cast<UMapProperty>(Property))
@@ -2077,7 +2077,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 		return NewLuaTable;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FSetProperty* SetProperty = CastField<FSetProperty>(Property))
 #else
 	if (USetProperty* SetProperty = Cast<USetProperty>(Property))
@@ -2094,7 +2094,7 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 		return NewLuaArray;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FStructProperty* StructProperty = CastField<FStructProperty>(Property))
 #else
 	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
@@ -2122,13 +2122,13 @@ FLuaValue ULuaState::FromUProperty(void* Buffer, UProperty * Property, bool& bSu
 FLuaValue ULuaState::StructToLuaTable(UScriptStruct * InScriptStruct, const uint8 * StructData)
 {
 	FLuaValue NewLuaTable = CreateLuaTable();
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> It(InScriptStruct); It; ++It)
 #else
 	for (TFieldIterator<UProperty> It(InScriptStruct); It; ++It)
 #endif
 	{
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 		FProperty* FieldProp = *It;
 #else
 		UProperty* FieldProp = *It;
@@ -2145,7 +2145,7 @@ FLuaValue ULuaState::StructToLuaTable(UScriptStruct * InScriptStruct, const TArr
 	return StructToLuaTable(InScriptStruct, StructData.GetData());
 }
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 void ULuaState::ToFProperty(void* Buffer, FProperty * Property, FLuaValue Value, bool& bSuccess, int32 Index)
 #else
 void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value, bool& bSuccess, int32 Index)
@@ -2169,7 +2169,7 @@ void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value,
 	LUAVALUE_PROP_SET(ClassProperty, Value.Object);
 	LUAVALUE_PROP_SET(ObjectProperty, Value.Object);
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FObjectPropertyBase* ObjectPropertyBase = CastField<FObjectPropertyBase>(Property);
 #else
 	UObjectPropertyBase* ObjectPropertyBase = Cast<UObjectPropertyBase>(Property);
@@ -2179,7 +2179,7 @@ void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value,
 		ObjectPropertyBase->SetObjectPropertyValue_InContainer(Buffer, Value.Object, Index);
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FWeakObjectProperty* WeakObjectProperty = CastField<FWeakObjectProperty>(Property);
 #else
 	UWeakObjectProperty* WeakObjectProperty = Cast<UWeakObjectProperty>(Property);
@@ -2191,7 +2191,7 @@ void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value,
 		return;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FMulticastDelegateProperty* MulticastProperty = CastField<FMulticastDelegateProperty>(Property))
 #else
 	if (UMulticastDelegateProperty* MulticastProperty = Cast<UMulticastDelegateProperty>(Property))
@@ -2208,7 +2208,7 @@ void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value,
 		return;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FDelegateProperty* DelegateProperty = CastField<FDelegateProperty>(Property))
 #else
 	if (UDelegateProperty* DelegateProperty = Cast<UDelegateProperty>(Property))
@@ -2225,7 +2225,7 @@ void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value,
 		return;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FStructProperty* StructProperty = CastField<FStructProperty>(Property))
 #else
 	if (UStructProperty* StructProperty = Cast<UStructProperty>(Property))
@@ -2244,7 +2244,7 @@ void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value,
 		return;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FArrayProperty* ArrayProperty = CastField<FArrayProperty>(Property))
 #else
 	if (UArrayProperty* ArrayProperty = Cast<UArrayProperty>(Property))
@@ -2262,7 +2262,7 @@ void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value,
 		return;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FMapProperty* MapProperty = CastField<FMapProperty>(Property))
 #else
 	if (UMapProperty* MapProperty = Cast<UMapProperty>(Property))
@@ -2284,7 +2284,7 @@ void ULuaState::ToUProperty(void* Buffer, UProperty * Property, FLuaValue Value,
 		return;
 	}
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	if (FSetProperty* SetProperty = CastField<FSetProperty>(Property))
 #else
 	if (USetProperty* SetProperty = Cast<USetProperty>(Property))
@@ -2310,7 +2310,7 @@ void ULuaState::LuaTableToStruct(FLuaValue & LuaValue, UScriptStruct * InScriptS
 	TArray<FLuaValue> TableKeys = ULuaBlueprintFunctionLibrary::LuaTableGetKeys(LuaValue);
 	for (FLuaValue TableKey : TableKeys)
 	{
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 		FProperty* StructProp = InScriptStruct->FindPropertyByName(TableKey.ToName());
 #else
 		UProperty* StructProp = InScriptStruct->FindPropertyByName(TableKey.ToName());
@@ -2323,7 +2323,7 @@ void ULuaState::LuaTableToStruct(FLuaValue & LuaValue, UScriptStruct * InScriptS
 	}
 }
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 void ULuaState::ToProperty(void* Buffer, FProperty * Property, FLuaValue Value, bool& bSuccess, int32 Index)
 {
 	ToFProperty(Buffer, Property, Value, bSuccess, Index);
@@ -2353,7 +2353,7 @@ FLuaValue ULuaState::GetLuaValueFromProperty(UObject * InObject, const FString &
 	}
 
 	UClass* Class = InObject->GetClass();
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FProperty* Property = nullptr;
 #else
 	UProperty* Property = nullptr;
@@ -2376,7 +2376,7 @@ bool ULuaState::SetPropertyFromLuaValue(UObject * InObject, const FString & Prop
 	}
 
 	UClass* Class = InObject->GetClass();
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FProperty* Property = nullptr;
 #else
 	UProperty* Property = nullptr;
@@ -2566,7 +2566,7 @@ TArray<FString> ULuaState::GetPropertiesNames(UObject * InObject)
 		return Names;
 	}
 
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	for (TFieldIterator<FProperty> It(Class); It; ++It)
 #else
 	for (TFieldIterator<UProperty> It(Class); It; ++It)

--- a/Source/LuaMachine/Private/LuaValue.cpp
+++ b/Source/LuaMachine/Private/LuaValue.cpp
@@ -90,7 +90,7 @@ void FLuaValue::Unref()
 		if (LuaRef != LUA_NOREF)
 		{
 			// special case for when the engine is shutting down
-#if ENGINE_MINOR_VERSION >= 24
+#if UE4_AT_LEAST(24)
 			if (IsEngineExitRequested())
 #else
 			if (GIsRequestingExit)

--- a/Source/LuaMachine/Public/LuaState.h
+++ b/Source/LuaMachine/Public/LuaState.h
@@ -8,7 +8,7 @@
 #include "LuaValue.h"
 #include "LuaCode.h"
 #include "Runtime/Core/Public/Containers/Queue.h"
-#include "Runtime/Launch/Resources/Version.h"
+#include "VersionInfo.h"
 #include "LuaDelegate.h"
 #include "LuaCommandExecutor.h"
 #include "LuaState.generated.h"
@@ -361,7 +361,7 @@ public:
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Lua")
 	static TArray<uint8> ToByteCode(const FString& Code, const FString& CodePath, FString& ErrorString);
 
-#if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 	FLuaValue FromUProperty(void* Buffer, FProperty* Property, bool& bSuccess, int32 Index = 0);
 	void ToUProperty(void* Buffer, FProperty* Property, FLuaValue Value, bool& bSuccess, int32 Index = 0);
 	FLuaValue FromFProperty(void* Buffer, FProperty* Property, bool& bSuccess, int32 Index = 0);

--- a/Source/LuaMachine/Public/VersionInfo.h
+++ b/Source/LuaMachine/Public/VersionInfo.h
@@ -1,0 +1,21 @@
+// Copyright 2018-2020 - Roberto De Ioris
+
+#pragma once
+#include "Runtime/Launch/Resources/Version.h"
+
+//Old-Style header guard incase multiple plugins have implementations of this header
+//and are in shared space.
+#ifndef UE_VERSION_INFO_MACROS
+#define UE_VERSION_INFO_MACROS
+
+//Will pass if we are 4.xx or 5+
+#define UE4_AT_LEAST(x) (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION >= x) || ENGINE_MAJOR_VERSION > 4
+//Will pass if we are < 4.xx
+#define UE4_LESS_THAN(x) (ENGINE_MAJOR_VERSION < 4 || (ENGINE_MAJOR_VERSION == 4 && ENGINE_MINOR_VERSION < x))
+
+//Will pass if we are 5.xx or 6+
+#define UE5_AT_LEAST(x) (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= x) || ENGINE_MAJOR_VERSION > 5
+//Will pass if we are < 5.xx
+#define UE5_LESS_THAN(x) (ENGINE_MAJOR_VERSION < 5 || (ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION < x))
+
+#endif //UE_VERSION_INFO_MACROS

--- a/Source/LuaMachineEditor/Private/LuaValueCustomization.cpp
+++ b/Source/LuaMachineEditor/Private/LuaValueCustomization.cpp
@@ -149,13 +149,13 @@ void FLuaValueCustomization::CustomizeChildren(TSharedRef<IPropertyHandle> Prope
 
 		if (!bAllowsRawCall)
 		{
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 			for (TFieldIterator<FProperty> FArgs(Function); FArgs && FArgs->PropertyFlags & CPF_Parm; ++FArgs)
 #else
 			for (TFieldIterator<UProperty> FArgs(Function); FArgs && FArgs->PropertyFlags & CPF_Parm; ++FArgs)
 #endif
 			{
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 				FProperty* Prop = *FArgs;
 				FStructProperty* LuaProp = CastField<FStructProperty>(Prop);
 #else
@@ -165,14 +165,14 @@ void FLuaValueCustomization::CustomizeChildren(TSharedRef<IPropertyHandle> Prope
 				if (!LuaProp)
 				{
 					// check for array ?
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 					FArrayProperty* ArrayProp = CastField<FArrayProperty>(Prop);
 #else
 					UArrayProperty* ArrayProp = Cast<UArrayProperty>(Prop);
 #endif
 					if (ArrayProp)
 					{
-#if ENGINE_MINOR_VERSION >= 25
+#if UE4_AT_LEAST(25)
 						LuaProp = CastField<FStructProperty>(ArrayProp->Inner);
 #else
 						LuaProp = Cast<UStructProperty>(ArrayProp->Inner);


### PR DESCRIPTION
I've added a new VersionInfo header with some helper defines to make engine versioning much easier and clear.
I use these same defines in other projects, they drastically reduce the amount of typing, and make it more clear what they are doing.
I've also added UE5 versions of the UE4 ones, and used them in two places (LuaBlueprintFunctionLibrary)
This change also fixes a whole bunch that were missed, plus a couple that were ever so slightly wrong.

I've tested in 4.24, 4.26 and 5.0 EA2
(I was going to test 4,21, but I don't have VS2017 installed anymore)