### PR TITLE
Old LuaState instance persist in UE console.

### DIFF
--- a/Source/LuaMachine/Private/LuaMachine.cpp
+++ b/Source/LuaMachine/Private/LuaMachine.cpp
@@ -79,6 +79,13 @@ void FLuaMachineModule::CleanupLuaStates(bool bIsSimulating)
 		{
 			PersistentLuaStates.Add(LuaStateClass, LuaStates[LuaStateClass]);
 		}
+		else
+		{
+			if(auto* LuaConsole = LuaStates[LuaStateClass]->GetLuaConsole())
+			{
+				IModularFeatures::Get().UnregisterModularFeature(IConsoleCommandExecutor::ModularFeatureName(), LuaConsole);
+			}
+		}
 	}
 
 	LuaStates = PersistentLuaStates;

--- a/Source/LuaMachine/Public/LuaState.h
+++ b/Source/LuaMachine/Public/LuaState.h
@@ -454,6 +454,8 @@ public:
 		return InStruct;
 	}
 
+	FORCEINLINE FLuaCommandExecutor* GetLuaConsole() { return &LuaConsole; }
+
 protected:
 	lua_State* L;
 	bool bDisabled;


### PR DESCRIPTION
- Try to unregister LuaConsole from UEConsole system if that Lua state is destroyed.
- Have to raise the accessibility level of LuaConsole* from LuaState by adding a getter function.