### PR TITLE
fix the "not initialized properly" errors/warnings.

### DIFF
--- a/Source/LuaMachine/Public/LuaState.h
+++ b/Source/LuaMachine/Public/LuaState.h
@@ -89,6 +89,18 @@ struct FLuaLibsLoader
 	UPROPERTY(EditAnywhere, Category = "Lua", meta = (DisplayName = "Load debug"))
 	bool bLoadDebug;
 
+	FLuaLibsLoader()
+		: bLoadBase(true)
+		, bLoadCoroutine(true)
+		, bLoadTable(true)
+		, bLoadIO(true)
+		, bLoadOS(true)
+		, bLoadString(true)
+		, bLoadMath(true)
+		, bLoadUTF8(true)
+		, bLoadDebug(false)
+	{}
+
 };
 
 USTRUCT(BlueprintType)
@@ -110,6 +122,12 @@ struct FLuaDebug
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Lua")
 	FString What;
+
+	FLuaDebug()
+		: CurrentLine(0)
+	{
+
+	}
 };
 
 USTRUCT(BlueprintType)


### PR DESCRIPTION
Initialized variables in FLuaLibsLoader and FLuaDebug so the engine doesnt complain and cause errors.
