### PR TITLE
Add Instruction Count Hook

### DIFF
--- a/Source/LuaMachine/Private/LuaState.cpp
+++ b/Source/LuaMachine/Private/LuaState.cpp
@@ -30,6 +30,7 @@ ULuaState::ULuaState()
 	bEnableLineHook = false;
 	bEnableCallHook = false;
 	bEnableReturnHook = false;
+	bEnableCountHook = false;
 	bRawLuaFunctionCall = false;
 
 	FCoreUObjectDelegates::GetPostGarbageCollect().AddUObject(this, &ULuaState::GCLuaDelegatesCheck);
@@ -248,10 +249,14 @@ ULuaState* ULuaState::GetLuaState(UWorld* InWorld)
 	{
 		DebugMask |= LUA_MASKRET;
 	}
+	if (bEnableCountHook)
+	{
+		DebugMask |= LUA_MASKCOUNT;
+	}
 
 	if (DebugMask != 0)
 	{
-		lua_sethook(L, Debug_Hook, DebugMask, 0);
+		lua_sethook(L, Debug_Hook, DebugMask, HookInstructionCount);
 	}
 
 	if (LuaCodeAsset)
@@ -877,6 +882,9 @@ void ULuaState::Debug_Hook(lua_State* L, lua_Debug* ar)
 		break;
 	case LUA_HOOKRET:
 		LuaState->ReceiveLuaReturnHook(LuaDebug);
+		break;
+	case LUA_HOOKCOUNT:
+		LuaState->ReceiveLuaCountHook(LuaDebug);
 		break;
 	default:
 		break;
@@ -1597,6 +1605,11 @@ void ULuaState::ReceiveLuaReturnHook_Implementation(const FLuaDebug & LuaDebug)
 }
 
 void ULuaState::ReceiveLuaLineHook_Implementation(const FLuaDebug & LuaDebug)
+{
+
+}
+
+void ULuaState::ReceiveLuaCountHook(const FLuaDebug & LuaDebug)
 {
 
 }

--- a/Source/LuaMachine/Public/LuaState.h
+++ b/Source/LuaMachine/Public/LuaState.h
@@ -208,6 +208,11 @@ public:
 	UFUNCTION(BlueprintNativeEvent, Category = "Lua", meta = (DisplayName = "Lua Return Hook"))
 	void ReceiveLuaReturnHook(const FLuaDebug& LuaDebug);
 
+	// Not BlueprintNativeEvent, as throwing a luaL_error from an RTTI call results in leaving the VM in an unexpected
+	// state and will result in exceptions
+	UFUNCTION(Category = "Lua", meta = (DisplayName = "Lua Count Hook"))
+	virtual void ReceiveLuaCountHook(const FLuaDebug& LuaDebug);
+
 	UFUNCTION(BlueprintCallable, Category = "Lua")
 	FLuaValue NewLuaUserDataObject(TSubclassOf<ULuaUserDataObject> LuaUserDataObjectClass, bool bTrackObject=true);
 
@@ -265,6 +270,14 @@ public:
 	/* Enable debug of each Lua return. The LuaReturnHook event will be triggered */
 	UPROPERTY(EditAnywhere, Category = "Lua")
 	bool bEnableReturnHook;
+
+	/* Enable debug for reaching a number of Lua instruction. The LuaCountHook event will be triggered */
+	UPROPERTY(EditAnywhere, Category = "Lua")
+	bool bEnableCountHook;
+
+	/* Number of instructions to wait for when the Count Hook is enabled */
+	UPROPERTY(EditAnywhere, Category = "Lua", Meta = (EditCondition = "bEnableCountHook"))
+	int32 HookInstructionCount = 25000;
 
 	UPROPERTY()
 	TMap<FString, ULuaBlueprintPackage*> LuaBlueprintPackages;


### PR DESCRIPTION
This PR adds a Count Hook, so that Lua States can stop execution when an infinite loop is assumed (or react in other ways).