### PR TITLE
Fix `print` when `bLuaOpenLibs` is `false`

### DIFF
--- a/Source/LuaMachine/Private/LuaState.cpp
+++ b/Source/LuaMachine/Private/LuaState.cpp
@@ -57,14 +57,6 @@ ULuaState* ULuaState::GetLuaState(UWorld* InWorld)
 		luaL_openlibs(L);
 	}
 
-	ULuaState** LuaExtraSpacePtr = (ULuaState**)lua_getextraspace(L);
-	*LuaExtraSpacePtr = this;
-	// get the global table
-	lua_pushglobaltable(L);
-	// override print
-	PushCFunction(ULuaState::TableFunction_print);
-	SetField(-2, "print");
-
 	// load "package" for allowing minimal setup
 	luaL_requiref(L, "package", luaopen_package, 1);
 	lua_pop(L, 1);
@@ -125,6 +117,14 @@ ULuaState* ULuaState::GetLuaState(UWorld* InWorld)
 			lua_pop(L, 1);
 		}
 	}
+
+	ULuaState** LuaExtraSpacePtr = (ULuaState**)lua_getextraspace(L);
+	*LuaExtraSpacePtr = this;
+	// get the global table
+	lua_pushglobaltable(L);
+	// override print
+	PushCFunction(ULuaState::TableFunction_print);
+	SetField(-2, "print");
 
 	GetField(-1, "package");
 	if (!OverridePackagePath.IsEmpty())


### PR DESCRIPTION
Currently, `print` doesn't work if `bLuaOpenLibs` is set to `false`, because it's being overridden when we execute `bLoadBase`.

This PR switches the order of these instruction (loads Lua libraries before overriding `print`) to fix the issue.

I'm a bit new to this lua pop/push so I hope I moved the right amount of code to the right place (it does work in my test case) 😄