### PR TITLE
Re-Import / Re-Import with new file options for ULuaCode

### DIFF
--- a/Source/LuaMachineEditor/Private/LuaCodeFactory.cpp
+++ b/Source/LuaMachineEditor/Private/LuaCodeFactory.cpp
@@ -132,3 +132,21 @@ uint32 FLuaCodeAssetTypeActions::GetCategories()
 {
 	return FLuaMachineEditorModule::Get().GetAssetCategory();
 }
+
+bool FLuaCodeAssetTypeActions::IsImportedAsset() const
+{
+	return true;
+}
+
+void FLuaCodeAssetTypeActions::GetResolvedSourceFilePaths( const TArray<UObject*>& TypeAssets, TArray<FString>& OutSourceFilePaths ) const
+{
+	for ( auto& Asset : TypeAssets )
+	{
+		const auto LuaCode = CastChecked<ULuaCode>( Asset );
+		if ( LuaCode->AssetImportData )
+		{
+			LuaCode->AssetImportData->ExtractFilenames( OutSourceFilePaths );
+		}
+	}
+}
+

--- a/Source/LuaMachineEditor/Private/LuaMachineEditor.cpp
+++ b/Source/LuaMachineEditor/Private/LuaMachineEditor.cpp
@@ -356,7 +356,7 @@ class SLuaMachineDebugger : public SCompoundWidget, public FGCObject
 		case ELuaValueType::Thread:
 			if (SelectedLuaState == Item->LuaTableValue.LuaState)
 			{
-				Value = "status: " + FindObject<UEnum>(ANY_PACKAGE, TEXT("ELuaThreadStatus"), true)->GetNameStringByIndex((int32)SelectedLuaState->GetLuaThreadStatus(Item->LuaTableValue)) + ", stack top: " + FString::FromInt(SelectedLuaState->GetLuaThreadStackTop(Item->LuaTableValue));
+				Value = "status: " + FindObject<UEnum>(nullptr, TEXT("/Script/LuaMachine.ELuaThreadStatus"), true)->GetNameStringByIndex((int32)SelectedLuaState->GetLuaThreadStatus(Item->LuaTableValue)) + ", stack top: " + FString::FromInt(SelectedLuaState->GetLuaThreadStackTop(Item->LuaTableValue));
 			}
 			break;
 		default:

--- a/Source/LuaMachineEditor/Public/LuaCodeFactory.h
+++ b/Source/LuaMachineEditor/Public/LuaCodeFactory.h
@@ -74,5 +74,7 @@ public:
 	//virtual void GetActions(const TArray<UObject*>& InObjects, FMenuBuilder& MenuBuilder) override;
 	//virtual void OpenAssetEditor(const TArray<UObject*>& InObjects, TSharedPtr<class IToolkitHost> EditWithinLevelEditor = TSharedPtr<IToolkitHost>()) override;
 	virtual uint32 GetCategories() override;
+	virtual bool IsImportedAsset() const override;
+	virtual void GetResolvedSourceFilePaths( const TArray<UObject*>& TypeAssets, TArray<FString>& OutSourceFilePaths ) const override;
 	// End of IAssetTypeActions interface
 };


### PR DESCRIPTION
- Update Asset Type Actions, to give "Reimport" and "Reimport With New File" options to ULuaCode

(You have to Import at least once with these changes before they will appear)