### PR TITLE
Fix Linux build with UE5

### DIFF
--- a/Source/LuaMachine/Private/LuaBlueprintFunctionLibrary.cpp
+++ b/Source/LuaMachine/Private/LuaBlueprintFunctionLibrary.cpp
@@ -12,7 +12,11 @@
 #include "IImageWrapper.h"
 #include "IImageWrapperModule.h"
 #include "IPlatformFilePak.h"
+#if ENGINE_MAJOR_VERSION >= 5
+#include "HAL/PlatformFileManager.h" 
+#else
 #include "HAL/PlatformFilemanager.h"
+#endif
 #if ENGINE_MAJOR_VERSION >= 5 && ENGINE_MINOR_VERSION > 0
 #include "AssetRegistry/IAssetRegistry.h"
 #include "AssetRegistry/AssetRegistryModule.h"


### PR DESCRIPTION
Hello. This pull request fixes #39 . Plugin will now build fine on Linux (and probably Mac) with UE4 or UE5.

With release of UE5 Epic had fixed a filename case issue they had with Perforce. Linux and Macs are case sensitive so it is important to get the include path case correct.