### PR TITLE
Let LuaComponent respect bImplicitSelf

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[{*.h,*.c,*.cpp,*.cs}]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
+insert_final_newline = true
+max_line_length = 140

--- a/Source/LuaMachine/Private/LuaComponent.cpp
+++ b/Source/LuaMachine/Private/LuaComponent.cpp
@@ -111,9 +111,13 @@ FLuaValue ULuaComponent::LuaCallFunction(const FString& Name, TArray<FLuaValue> 
 
 	int32 ItemsToPop = L->GetFieldFromTree(Name, bGlobal);
 
+  bool bAddSelfArg = bImplicitSelfForLuaCalls && bImplicitSelf;
 	// first argument (self/actor)
-	L->PushValue(-(ItemsToPop + 1));
-	int NArgs = 1;
+  if (bAddSelfArg)
+  {
+    L->PushValue(-(ItemsToPop + 1));
+  }
+	int NArgs = bAddSelfArg ? 1 : 0;
 	for (FLuaValue& Arg : Args)
 	{
 		L->FromLuaValue(Arg);
@@ -151,9 +155,13 @@ TArray<FLuaValue> ULuaComponent::LuaCallFunctionMulti(FString Name, TArray<FLuaV
 	int32 ItemsToPop = L->GetFieldFromTree(Name, bGlobal);
 	int32 StackTop = L->GetTop();
 
+  bool bAddSelfArg = bImplicitSelfForLuaCalls && bImplicitSelf;
 	// first argument (self/actor)
-	L->PushValue(-(ItemsToPop + 1));
-	int NArgs = 1;
+  if (bAddSelfArg)
+  {
+    L->PushValue(-(ItemsToPop + 1));
+  }
+	int NArgs = bAddSelfArg ? 1 : 0;
 	for (FLuaValue& Arg : Args)
 	{
 		L->FromLuaValue(Arg);
@@ -199,11 +207,15 @@ FLuaValue ULuaComponent::LuaCallValue(FLuaValue Value, TArray<FLuaValue> Args)
 
 	// push function
 	L->FromLuaValue(Value);
+  bool bAddSelfArg = bImplicitSelfForLuaCalls && bImplicitSelf;
 	// push component pointer as userdata
-	L->NewUObject(this, nullptr);
+  if (bAddSelfArg)
+  {
+    L->NewUObject(this, nullptr);
+  }
 	L->SetupAndAssignUserDataMetatable(this, Metatable, nullptr);
 
-	int NArgs = 1;
+	int NArgs = bAddSelfArg ? 1 : 0;
 	for (FLuaValue& Arg : Args)
 	{
 		L->FromLuaValue(Arg);
@@ -282,11 +294,15 @@ TArray<FLuaValue> ULuaComponent::LuaCallValueMulti(FLuaValue Value, TArray<FLuaV
 	L->FromLuaValue(Value);
 	int32 StackTop = L->GetTop();
 
-	// push component pointer as userdata
-	L->NewUObject(this, nullptr);
+  bool bAddSelfArg = bImplicitSelfForLuaCalls && bImplicitSelf;
+  if (bAddSelfArg)
+  {
+	  // push component pointer as userdata
+    L->NewUObject(this, nullptr);
+  }
 	L->SetupAndAssignUserDataMetatable(this, Metatable, nullptr);
 
-	int NArgs = 1;
+	int NArgs = bAddSelfArg ? 1 : 0;
 	for (FLuaValue& Arg : Args)
 	{
 		L->FromLuaValue(Arg);

--- a/Source/LuaMachine/Public/LuaComponent.h
+++ b/Source/LuaMachine/Public/LuaComponent.h
@@ -43,8 +43,24 @@ public:
 	UPROPERTY(EditAnywhere, Category="Lua")
 	bool bLogError;
 
-	UPROPERTY(EditAnywhere, Category = "Lua")
+  /**
+   * Whether to implicitly pass this component as the first argument (usually <code>self</code> when calling a Lua
+   * function.
+   *
+   * Currently, this is only respected by <code>ULuaState::MetaTableFunction__call</code> and
+   * <code>ULuaState::MetaTableFunction__rawcall</code>. If you want this to work for <code>LuaCall...</code> functions
+   * as well, you need to enable <code>bImplicitSelfForFunctionCalls</code>, too.
+   */
+  UPROPERTY(EditAnywhere, Category = "Lua")
 	bool bImplicitSelf;
+
+  /**
+   * When enabled, <code>bImplicitSelf</code> will be respected by all <code>LuaCall...</code> functions.
+   *
+   * See <a href="https://github.com/rdeioris/LuaMachine/pull/77">this PR</a>.
+   */
+	UPROPERTY(EditAnywhere, Category = "Lua")
+	bool bImplicitSelfForLuaCalls;
 
 	UPROPERTY(EditAnywhere, Category = "Lua")
 	TArray<FString> GlobalNames;


### PR DESCRIPTION
My idea is to connect a Lua table to an Actor, but without "mixing" them.

So `UShipLuaComponent::LuaObject` references the Lua table:
```cpp
/** The Lua table that is connected to this actor component. */
FLuaValue LuaObject;
```

When the actor is spawned, a Lua table should be created for it:
```cpp
void UShipLuaComponent::BeginPlay()
{
  Super::BeginPlay();

  const TArray Args = {FLuaValue(this)};
  LuaObject = LuaCallFunction("Ship.Init", Args, true);
}
```
```lua
--- This function is called by the engine whenever a [Ship] actor is spawned.
---@param actor ShipActor the engine actor that is connected to this table
function Ship.Init(actor)
  local instance = setmetatable({}, Ship)
  instance.Actor = actor
  return instance
end
```

The reason I do this is because modders should be able to add functions to `Ship`:
```lua
-- HasTarget should not have to exist in the LuaComponent
function Ship:HasTarget()
  return self.Target ~= nil
end
```
But they can also delegate to the `LuaComponent`:
```lua
---@param input number Value from `0.0` - `1.0`
function Ship:SetThrottleInput(input)
  self.Actor.SetThrottleInput(input)
end
```

And when the engine calls a function like `Tick`, `self` should be the Lua table, not the `LuaComponent`:
```lua
function Ship:Tick(deltaTime)
  print("Tick "..deltaTime)
end
```

To achieve this, I need to be able to call a Lua function without passing the `LuaComponent` implicitly as `self`. I thought that the setting `bImplicitSelf = false` would achieve this. But in methods like `LuaCallFunction`, this flag is not respected.

This PR fixes that.

Unfortunately, this is a breaking change. To preserve the old behavior, `bImplicitSelf` would need to default to `true`, but that would also be a breaking change.

Maybe I'm not getting it right anyway. In that case, maybe a new flag could be introduced to control the behavior? Then it would also not be breaking.

