### PR TITLE
Respect the function owner when calling a function from Lua

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+root = true
+
+[{*.h,*.c,*.cpp,*.cs}]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+tab_width = 4
+indent_style = tab
+insert_final_newline = true
+max_line_length = 140

--- a/Source/LuaMachine/Private/LuaState.cpp
+++ b/Source/LuaMachine/Private/LuaState.cpp
@@ -747,10 +747,18 @@ void ULuaState::FromLuaValue(FLuaValue& LuaValue, UObject* CallContext, lua_Stat
 		}
 		if (CallContext)
 		{
-			UObject* FunctionOwner = CallContext;
-			if (ULuaComponent* LuaComponent = Cast<ULuaComponent>(CallContext))
+			const UObject* FunctionOwner;
+			if (LuaValue.Object != nullptr)
+			{
+				FunctionOwner = LuaValue.Object;
+			}
+			else if (const ULuaComponent* LuaComponent = Cast<ULuaComponent>(CallContext))
 			{
 				FunctionOwner = LuaComponent->GetOwner();
+			}
+			else
+			{
+				FunctionOwner = CallContext;
 			}
 
 			if (FunctionOwner)
@@ -1344,9 +1352,11 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 	bool bImplicitSelf = false;
 	int StackPointer = 2;
 
+	UFunction* Function = LuaCallContext->Function.Get();
 	if (ULuaComponent* LuaComponent = Cast<ULuaComponent>(CallScope))
 	{
-		CallScope = LuaComponent->GetOwner();
+		UClass* DeclaringClass = Cast<UClass>(Function->GetOuter());
+		CallScope = DeclaringClass->IsChildOf(ULuaComponent::StaticClass()) ? LuaCallContext->Context.Get() : LuaComponent->GetOwner();
 		if (NArgs > 0)
 		{
 			FLuaValue LuaFirstArgument = LuaState->ToLuaValue(StackPointer, L);
@@ -1369,13 +1379,13 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 	}
 
 	FScopeCycleCounterUObject ObjectScope(CallScope);
-	FScopeCycleCounterUObject FunctionScope(LuaCallContext->Function.Get());
+	FScopeCycleCounterUObject FunctionScope(Function);
 
 	void* Parameters = FMemory_Alloca(LuaCallContext->Function->ParmsSize);
 	FMemory::Memzero(Parameters, LuaCallContext->Function->ParmsSize);
 
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
-	for (TFieldIterator<FProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
+	for (TFieldIterator<FProperty> It(Function); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 	{
 		FProperty* Prop = *It;
 #else
@@ -1397,7 +1407,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 
 	// arguments
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
-	for (TFieldIterator<FProperty> FArgs(LuaCallContext->Function.Get()); FArgs && ((FArgs->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm); ++FArgs)
+	for (TFieldIterator<FProperty> FArgs(Function); FArgs && ((FArgs->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm); ++FArgs)
 	{
 		FProperty* Prop = *FArgs;
 		FStructProperty* LuaProp = CastField<FStructProperty>(Prop);
@@ -1454,7 +1464,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 	}
 
 	LuaState->InceptionLevel++;
-	CallScope->ProcessEvent(LuaCallContext->Function.Get(), Parameters);
+	CallScope->ProcessEvent(Function, Parameters);
 	check(LuaState->InceptionLevel > 0);
 	LuaState->InceptionLevel--;
 
@@ -1487,7 +1497,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 
 	// get return value
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
-	for (TFieldIterator<FProperty> FArgs(LuaCallContext->Function.Get()); FArgs; ++FArgs)
+	for (TFieldIterator<FProperty> FArgs(Function); FArgs; ++FArgs)
 	{
 		FProperty* Prop = *FArgs;
 #else
@@ -1550,7 +1560,7 @@ int ULuaState::MetaTableFunction__call(lua_State* L)
 	}
 
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
-	for (TFieldIterator<FProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
+	for (TFieldIterator<FProperty> It(Function); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 #else
 	for (TFieldIterator<UProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 #endif
@@ -1582,9 +1592,11 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 	bool bImplicitSelf = false;
 	int StackPointer = 2;
 
+	UFunction* Function = LuaCallContext->Function.Get();
 	if (ULuaComponent* LuaComponent = Cast<ULuaComponent>(CallScope))
 	{
-		CallScope = LuaComponent->GetOwner();
+		UClass* DeclaringClass = Cast<UClass>(Function->GetOuter());
+		CallScope = DeclaringClass->IsChildOf(ULuaComponent::StaticClass()) ? LuaCallContext->Context.Get() : LuaComponent->GetOwner();
 		if (NArgs > 0)
 		{
 			FLuaValue LuaFirstArgument = LuaState->ToLuaValue(StackPointer, L);
@@ -1607,13 +1619,13 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 	}
 
 	FScopeCycleCounterUObject ObjectScope(CallScope);
-	FScopeCycleCounterUObject FunctionScope(LuaCallContext->Function.Get());
+	FScopeCycleCounterUObject FunctionScope(Function);
 
 	void* Parameters = FMemory_Alloca(LuaCallContext->Function->ParmsSize);
 	FMemory::Memzero(Parameters, LuaCallContext->Function->ParmsSize);
 
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
-	for (TFieldIterator<FProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
+	for (TFieldIterator<FProperty> It(Function); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 	{
 		FProperty* Prop = *It;
 #else
@@ -1635,7 +1647,7 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 
 	// arguments
 #if ENGINE_MAJOR_VERSION > 4 ||  ENGINE_MINOR_VERSION >= 25
-	for (TFieldIterator<FProperty> FArgs(LuaCallContext->Function.Get()); FArgs && ((FArgs->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm); ++FArgs)
+	for (TFieldIterator<FProperty> FArgs(Function); FArgs && ((FArgs->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm); ++FArgs)
 	{
 		FProperty* Prop = *FArgs;
 #else
@@ -1648,7 +1660,7 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 	}
 
 	LuaState->InceptionLevel++;
-	CallScope->ProcessEvent(LuaCallContext->Function.Get(), Parameters);
+	CallScope->ProcessEvent(Function, Parameters);
 	check(LuaState->InceptionLevel > 0);
 	LuaState->InceptionLevel--;
 
@@ -1681,7 +1693,7 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 
 	// get return value
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
-	for (TFieldIterator<FProperty> FArgs(LuaCallContext->Function.Get()); FArgs; ++FArgs)
+	for (TFieldIterator<FProperty> FArgs(Function); FArgs; ++FArgs)
 	{
 		FProperty* Prop = *FArgs;
 #else
@@ -1707,7 +1719,7 @@ int ULuaState::MetaTableFunction__rawcall(lua_State * L)
 	}
 
 #if ENGINE_MAJOR_VERSION > 4 || ENGINE_MINOR_VERSION >= 25
-	for (TFieldIterator<FProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
+	for (TFieldIterator<FProperty> It(Function); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 #else
 	for (TFieldIterator<UProperty> It(LuaCallContext->Function.Get()); (It && It->HasAnyPropertyFlags(CPF_Parm)); ++It)
 #endif
@@ -2985,10 +2997,18 @@ void ULuaState::SetupAndAssignUserDataMetatable(UObject * Context, TMap<FString,
 		// first check for UFunction
 		if (Pair.Value.Type == ELuaValueType::UFunction)
 		{
-			UObject* FunctionOwner = Context;
-			if (ULuaComponent* LuaComponent = Cast<ULuaComponent>(Context))
+			const UObject* FunctionOwner;
+			if (Pair.Value.Object != nullptr)
+			{
+				FunctionOwner = Pair.Value.Object;
+			}
+			else if (const ULuaComponent* LuaComponent = Cast<ULuaComponent>(Context))
 			{
 				FunctionOwner = LuaComponent->GetOwner();
+			}
+			else
+			{
+				FunctionOwner = Context;
 			}
 
 			if (FunctionOwner)


### PR DESCRIPTION
I want to achieve this:
```cpp
UShipLuaComponent::UShipLuaComponent()
{
  Table.Add("GetActorLocation", FLuaValue::Function(GET_FUNCTION_NAME_CHECKED(UShipLuaComponent, GetActorLocation)));
}

FLuaValue UShipLuaComponent::GetActorLocation() {
  ...
}
```
And then have this
```lua
self.GetActorLocation()
```
To call the function on the component.

However, this currently calls `AShip::GetActorLocation()` instead of `UShipLuaComponent::GetActorLocation()`. 

This seems to be by design.

The downside is that the owning component now needs to declare Lua-compatible functions, leading to tight coupling.

With the suggested change, the user can instead use `FunctionOfObject`:

```cpp
Table.Add("GetActorLocation", FLuaValue::FunctionOfObject(this, GET_FUNCTION_NAME_CHECKED(UShipLuaComponent, GetActorLocation)));
```

And have the function called on the component instead of the owner. This change is backward-compatible.